### PR TITLE
Run without GUI Display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod args;
+mod audio;
 mod config;
 mod dsp;
 mod gamma_table;
 mod led;
-mod audio;
 
 use gui::Gui;
 
@@ -17,6 +17,7 @@ pub fn main() -> iced::Result {
     {
         iced::application("Audio Reactive Renderer", Gui::update, Gui::view)
             .subscription(Gui::subscription)
+            .theme(|_| iced::Theme::Dark)
             .exit_on_close_request(false)
             .run()
     }


### PR DESCRIPTION
Make cli args that let us run this app without the gui display. Necessary features for this include

- [x] selecting the recording device in the CLI args
- [ ] switching the preset at runtime
- [x] shutting down the program with ctrl-c or some other keyboard shortcut
